### PR TITLE
Fix CUDA 11 LaunchError

### DIFF
--- a/farneback3d/_filtering.py
+++ b/farneback3d/_filtering.py
@@ -79,7 +79,7 @@ def _call_smooth_cuda_gauss(gpuimg, gpuresult, sigma, kernelsize,  filter_mask=N
 
 
 def smooth_cuda_gauss(img, sigma, kernelsize, rtn_gpu=None, filter_mask=None):
-    if not rtn_gpu:
+    if rtn_gpu is None:
         rtn_gpu = gpuarray.GPUArray(img.shape, np.float32)
 
     if isinstance(img, np.ndarray):

--- a/farneback3d/filtering.cu
+++ b/farneback3d/filtering.cu
@@ -39,7 +39,7 @@ __global__ void convolve3d_gauss(float *__restrict__ in,
                                  float sigmaX,
                                  float sigmaY,
                                  float sigmaZ,
-                                 bool filterNonZerosOnly)
+                                 int filterNonZerosOnly)
 {
     int x = blockIdx.x * blockDim.x + threadIdx.x;
     int y = blockIdx.y * blockDim.y + threadIdx.y;
@@ -114,7 +114,7 @@ __global__ void convolve3d_gauss_with_mask(float *__restrict__ in,
                                            float sigmaX,
                                            float sigmaY,
                                            float sigmaZ,
-                                           bool filterNonZerosOnly)
+                                           int filterNonZerosOnly)
 {
     int x = blockIdx.x * blockDim.x + threadIdx.x;
     int y = blockIdx.y * blockDim.y + threadIdx.y;

--- a/tests/test_synthetic_volumes.py
+++ b/tests/test_synthetic_volumes.py
@@ -57,8 +57,8 @@ def test_moving_cube_larger_distance():
 
 def test_default_values():
 
-    a = np.ones([20] * 3)
-    b = np.ones([20] * 3)
+    a = np.ones([20] * 3, dtype=np.float32)
+    b = np.ones([20] * 3, dtype=np.float32)
 
     optflow = farneback3d.Farneback()
 
@@ -67,6 +67,6 @@ def test_default_values():
 
 
 if __name__ == "__main__":
-    # test_moving_cube()
-    # test_moving_cube_larger_distance()
+    test_moving_cube()
+    test_moving_cube_larger_distance()
     test_default_values()


### PR DESCRIPTION
Flow estimation failed when using CUDA 11 with the error `pycuda._driver.LaunchError: cuLaunchKernel failed: too many resources requested for launch`.

This commit fixes issue #5.